### PR TITLE
fix:  use custom renderer for screens

### DIFF
--- a/src/main-renderers/rendered-value.pr
+++ b/src/main-renderers/rendered-value.pr
@@ -31,5 +31,6 @@ Rendered as:
 {[ case "Shadow" ]}{[ inject "rendered-shadow" context token.value /]}
 {[ case "Border" ]}{[ inject "rendered-border" context token.value /]}
 {[ case "Measure" ]}{[ inject "rendered-measure" context token.value /]}
-{[ case "Gradient" ]}{[ inject "rendered-gradient" context token.value /]} 
+{[ case "Gradient" ]}{[ inject "rendered-gradient" context token.value /]}
+{[ case "Text" ]}{{ token.value.text }}
 {[/]}

--- a/src/main-renderers/tailwind-variables.pr
+++ b/src/main-renderers/tailwind-variables.pr
@@ -36,7 +36,7 @@ module.exports = {
         {[ const screenTokens = ds.tokensByGroupId(group.id) /]}
         {[ for token in screenTokens ]}
         {[ let tokenName = token.name.replacing("$", "").replacing(" ", "-") /]}
-        '{{ tokenName }}': '{[ inject "rendered-token-var" context token /]}'
+        '{{ tokenName }}': '{[ inject "rendered-value" context token /]}',
         {[/]}
         {[/]}
     {[/]}


### PR DESCRIPTION
## Changes

- The `rendered-token-var` blueprint exported data as `'--screens-2xl: ; '` since the `rendered-value` blueprint used within didn't support outputs of type `Text`.
- This PR adds support for it.